### PR TITLE
attributes bug fix

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -680,7 +680,9 @@ class dump(DumpCommand):
                 boxdata['ybr'] = box.ybr
                 boxdata['outside'] = box.lost
                 boxdata['occluded'] = box.occluded
-                boxdata['attributes'] = box.attributes
+                boxdata['attributes'] = []
+                for attr in box.attributes:
+                    boxdata['attributes'].append(attr.text)
                 boxes[int(box.frame)] = boxdata
             result['boxes'] = boxes
             annotations[int(id)] = result


### PR DESCRIPTION
According to our conversation before :

Thank you Audai! Can you send a pull request on Github and I will merge it?
Carl

On Mon, Jan 23, 2017 at 5:59 AM Audai Shmalih <audai.shmalih@viisights.com> wrote:
Hi Carl,

I'm using your amazing Vatic system, and I found a bug when you have attributes and want to export the annotaions in json format it's failed!
I fixed the bug by doing some changes in vatic/cli.py
change the line 683: 
 boxdata['attributes'] = box.attributes

to
boxdata['attributes'] = []
for attr in box.attributes:
    boxdata['attributes'].append(attr.text)